### PR TITLE
Feat/issue #5 회원가입 모달 UI 구현

### DIFF
--- a/src/shared/components/auth/AuthModal.tsx
+++ b/src/shared/components/auth/AuthModal.tsx
@@ -1,0 +1,20 @@
+import { LoginModal } from './LoginModal';
+import { RegisterModal } from './RegisterModal';
+
+interface AuthModalsProps {
+  modal: 'login' | 'register' | null;
+  setModal: React.Dispatch<React.SetStateAction<'login' | 'register' | null>>;
+}
+
+export const AuthModal = ({ modal, setModal }: AuthModalsProps) => {
+  return (
+    <>
+      {modal === 'login' && (
+        <LoginModal onClose={() => setModal(null)} onSwitch={() => setModal('register')} />
+      )}
+      {modal === 'register' && (
+        <RegisterModal onClose={() => setModal(null)} onSwitch={() => setModal('login')} />
+      )}
+    </>
+  );
+};

--- a/src/shared/components/auth/LoginModal.tsx
+++ b/src/shared/components/auth/LoginModal.tsx
@@ -3,14 +3,12 @@ import { useState } from 'react';
 import { Eye, EyeOff, X } from 'lucide-react';
 
 type LoginModalProps = {
-  isOpen: boolean;
   onClose: () => void;
+  onSwitch: () => void;
 };
 
-export const LoginModal = ({ isOpen, onClose }: LoginModalProps) => {
+export const LoginModal = ({ onClose, onSwitch }: LoginModalProps) => {
   const [showPassword, setShowPassword] = useState(false);
-
-  if (!isOpen) return null;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 px-4">
@@ -59,7 +57,10 @@ export const LoginModal = ({ isOpen, onClose }: LoginModalProps) => {
 
         {/* 회원가입 링크 */}
         <p className="mt-4 text-center text-sm text-gray-500 sm:text-xs">
-          아직 계정이 없으신가요? <button className="text-primary hover:underline">회원가입</button>
+          아직 계정이 없으신가요?{' '}
+          <button className="text-primary hover:underline" onClick={onSwitch}>
+            회원가입
+          </button>
         </p>
       </div>
     </div>

--- a/src/shared/components/auth/RegisterModal.tsx
+++ b/src/shared/components/auth/RegisterModal.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+
+import { Eye, EyeOff, X } from 'lucide-react';
+
+type RegisterModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export const RegisterModal = ({ isOpen, onClose }: RegisterModalProps) => {
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 px-4">
+      <div className="relative w-full max-w-sm animate-fade-in rounded-2xl bg-white p-6 shadow-xl sm:max-w-xs">
+        {/* 닫기 버튼 */}
+        <button
+          onClick={onClose}
+          className="absolute right-4 top-4 text-gray-400 hover:text-gray-600"
+          aria-label="모달 닫기"
+        >
+          <X className="h-5 w-5" />
+        </button>
+
+        {/* 제목 */}
+        <h2 className="mb-6 text-center text-xl font-bold text-gray-800 sm:text-lg md:text-2xl">
+          회원가입
+        </h2>
+
+        {/* 닉네임 입력 */}
+        <input
+          type="text"
+          placeholder="닉네임 (중복 확인)"
+          className="mb-4 w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-primary focus:outline-none sm:text-xs md:text-sm"
+        />
+
+        {/* 아이디 입력 */}
+        <input
+          type="text"
+          placeholder="아이디 (중복 확인)"
+          className="mb-4 w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-primary focus:outline-none sm:text-xs md:text-sm"
+        />
+
+        {/* 비밀번호 입력 */}
+        <div className="relative mb-4">
+          <input
+            type={showPassword ? 'text' : 'password'}
+            placeholder="비밀번호"
+            className="w-full rounded-lg border border-gray-300 px-4 py-2 pr-10 text-sm focus:border-primary focus:outline-none sm:text-xs md:text-sm"
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-primary"
+          >
+            {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+          </button>
+        </div>
+
+        {/* 비밀번호 확인 */}
+        <div className="relative mb-6">
+          <input
+            type={showConfirmPassword ? 'text' : 'password'}
+            placeholder="비밀번호 확인"
+            className="w-full rounded-lg border border-gray-300 px-4 py-2 pr-10 text-sm focus:border-primary focus:outline-none sm:text-xs md:text-sm"
+          />
+          <button
+            type="button"
+            onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-primary"
+          >
+            {showConfirmPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+          </button>
+        </div>
+
+        {/* 회원가입 버튼 */}
+        <button className="w-full rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 sm:text-xs md:text-sm">
+          회원가입
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/shared/components/auth/RegisterModal.tsx
+++ b/src/shared/components/auth/RegisterModal.tsx
@@ -28,33 +28,51 @@ export const RegisterModal = ({ onClose, onSwitch }: RegisterModalProps) => {
           회원가입
         </h2>
 
-        <input
-          type="text"
-          placeholder="닉네임 (중복 확인)"
-          className="mb-4 w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-primary focus:outline-none sm:text-xs md:text-sm"
-        />
+        {/* 닉네임 */}
+        <div className="mb-4 flex gap-2">
+          <div className="flex-1">
+            <input
+              type="text"
+              placeholder="닉네임"
+              className="h-[35px] w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-primary focus:outline-none sm:text-xs md:text-sm"
+            />
+          </div>
+          <button className="h-[35px] w-[70px] rounded-lg bg-primary/40 text-xs font-extrabold text-black/40 hover:bg-primary/60">
+            중복확인
+          </button>
+        </div>
 
-        <input
-          type="text"
-          placeholder="아이디 (중복 확인)"
-          className="mb-4 w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-primary focus:outline-none sm:text-xs md:text-sm"
-        />
+        {/* 아이디 */}
+        <div className="mb-4 flex gap-2">
+          <div className="flex-1">
+            <input
+              type="text"
+              placeholder="아이디"
+              className="h-[35px] w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-primary focus:outline-none sm:text-xs md:text-sm"
+            />
+          </div>
+          <button className="h-[35px] w-[70px] rounded-lg bg-primary/40 text-xs font-extrabold text-black/40 hover:bg-primary/60">
+            중복확인
+          </button>
+        </div>
 
+        {/* 비밀번호 */}
         <div className="relative mb-4">
           <input
             type={showPassword ? 'text' : 'password'}
             placeholder="비밀번호"
-            className="w-full rounded-lg border border-gray-300 px-4 py-2 pr-10 text-sm focus:border-primary focus:outline-none sm:text-xs md:text-sm"
+            className="h-[35px] w-full rounded-lg border border-gray-300 px-4 py-2 pr-10 text-sm focus:border-primary focus:outline-none sm:text-xs md:text-sm"
           />
           <button
             type="button"
             onClick={() => setShowPassword(!showPassword)}
-            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-primary"
+            className="absolute right-2 top-1/2 h-[35px] -translate-y-1/2 text-gray-500 hover:text-primary"
           >
             {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
           </button>
         </div>
 
+        {/* 비밀번호 확인 */}
         <div className="relative mb-6">
           <input
             type={showConfirmPassword ? 'text' : 'password'}
@@ -70,10 +88,12 @@ export const RegisterModal = ({ onClose, onSwitch }: RegisterModalProps) => {
           </button>
         </div>
 
+        {/* 회원가입 버튼 */}
         <button className="w-full rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 sm:text-xs md:text-sm">
           회원가입
         </button>
 
+        {/* 로그인으로 전환 */}
         <p className="mt-4 text-center text-sm text-gray-500 sm:text-xs">
           이미 계정이 있으신가요?{' '}
           <button className="text-primary hover:underline" onClick={onSwitch}>

--- a/src/shared/components/auth/RegisterModal.tsx
+++ b/src/shared/components/auth/RegisterModal.tsx
@@ -3,15 +3,13 @@ import { useState } from 'react';
 import { Eye, EyeOff, X } from 'lucide-react';
 
 type RegisterModalProps = {
-  isOpen: boolean;
   onClose: () => void;
+  onSwitch: () => void;
 };
 
-export const RegisterModal = ({ isOpen, onClose }: RegisterModalProps) => {
+export const RegisterModal = ({ onClose, onSwitch }: RegisterModalProps) => {
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-
-  if (!isOpen) return null;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 px-4">
@@ -30,21 +28,18 @@ export const RegisterModal = ({ isOpen, onClose }: RegisterModalProps) => {
           회원가입
         </h2>
 
-        {/* 닉네임 입력 */}
         <input
           type="text"
           placeholder="닉네임 (중복 확인)"
           className="mb-4 w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-primary focus:outline-none sm:text-xs md:text-sm"
         />
 
-        {/* 아이디 입력 */}
         <input
           type="text"
           placeholder="아이디 (중복 확인)"
           className="mb-4 w-full rounded-lg border border-gray-300 px-4 py-2 text-sm focus:border-primary focus:outline-none sm:text-xs md:text-sm"
         />
 
-        {/* 비밀번호 입력 */}
         <div className="relative mb-4">
           <input
             type={showPassword ? 'text' : 'password'}
@@ -60,7 +55,6 @@ export const RegisterModal = ({ isOpen, onClose }: RegisterModalProps) => {
           </button>
         </div>
 
-        {/* 비밀번호 확인 */}
         <div className="relative mb-6">
           <input
             type={showConfirmPassword ? 'text' : 'password'}
@@ -76,10 +70,16 @@ export const RegisterModal = ({ isOpen, onClose }: RegisterModalProps) => {
           </button>
         </div>
 
-        {/* 회원가입 버튼 */}
         <button className="w-full rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary/90 sm:text-xs md:text-sm">
           회원가입
         </button>
+
+        <p className="mt-4 text-center text-sm text-gray-500 sm:text-xs">
+          이미 계정이 있으신가요?{' '}
+          <button className="text-primary hover:underline" onClick={onSwitch}>
+            로그인
+          </button>
+        </p>
       </div>
     </div>
   );

--- a/src/shared/components/auth/index.ts
+++ b/src/shared/components/auth/index.ts
@@ -1,2 +1,3 @@
 export { RegisterModal } from './RegisterModal';
 export { LoginModal } from './LoginModal';
+export { AuthModal } from './AuthModal';

--- a/src/shared/components/auth/index.ts
+++ b/src/shared/components/auth/index.ts
@@ -1,1 +1,2 @@
+export { RegisterModal } from './RegisterModal';
 export { LoginModal } from './LoginModal';

--- a/src/shared/components/layout/Header.tsx
+++ b/src/shared/components/layout/Header.tsx
@@ -4,138 +4,133 @@ import { Link, useLocation } from 'react-router-dom';
 import { Bell, Menu, NotebookPen, TreeDeciduous, Trees, UserRound } from 'lucide-react';
 
 import Logo from '../../assets/todak.svg';
-import { LoginModal } from '../auth';
 
-// 임시 로그인 상태 (백엔드 연동 전)
-const isLoggedIn = false;
-const userName = '이지호';
+type HeaderProps = {
+  onLoginClick: () => void;
+};
 
-export const Header = () => {
+export const Header = ({ onLoginClick }: HeaderProps) => {
   const [menuOpen, setMenuOpen] = useState(false);
-  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false);
   const location = useLocation();
+  const isLoggedIn = false;
+  const userName = '이지호';
 
   const isActive = (path: string) => location.pathname === path;
 
   return (
-    <>
-      <header className="w-full border-b bg-white px-4 py-3 shadow-sm">
-        <div className="flex items-center justify-between px-2 md:px-6 lg:px-12">
-          {/* 로고 */}
-          <Link to="/" className="flex items-center gap-2">
-            <img src={Logo} alt="토닥 로고" className="h-7 w-auto md:h-10" />
-          </Link>
+    <header className="w-full border-b bg-white px-4 py-3 shadow-sm">
+      <div className="flex items-center justify-between px-2 md:px-6 lg:px-12">
+        {/* 로고 */}
+        <Link to="/" className="flex items-center gap-2">
+          <img src={Logo} alt="토닥 로고" className="h-7 w-auto md:h-10" />
+        </Link>
 
-          {/* 데스크탑 메뉴 */}
-          <nav className="hidden items-center gap-6 md:flex">
-            {isLoggedIn ? (
-              <>
-                <Link
-                  to="/"
-                  className={`font-medium hover:text-primary ${
-                    isActive('/') ? 'font-semibold text-primary' : 'text-gray-600'
-                  }`}
-                >
-                  마음나무
-                </Link>
-                <Link
-                  to="/diary"
-                  className={`font-medium hover:text-primary ${
-                    isActive('/diary') ? 'font-semibold text-primary' : 'text-gray-600'
-                  }`}
-                >
-                  일기장
-                </Link>
-                <Link
-                  to="/forests"
-                  className={`font-medium hover:text-primary ${
-                    isActive('/forests') ? 'font-semibold text-primary' : 'text-gray-600'
-                  }`}
-                >
-                  이웃숲
-                </Link>
-                <button className="relative" aria-label="알림">
-                  <Bell className="h-5 w-5 text-gray-600 hover:text-primary" />
-                </button>
-                <Link
-                  to="/mypage"
-                  className="flex items-center gap-1 rounded-full bg-primary/40 px-4 py-1.5 text-xs font-medium text-black/60 transition-colors hover:bg-primary/60"
-                >
-                  <UserRound className="h-4 w-4" />
-                  {userName}
-                </Link>
-              </>
-            ) : (
-              <button
-                onClick={() => setIsLoginModalOpen(true)}
-                className="flex items-center gap-1 rounded-full bg-primary/85 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary/100"
+        {/* 데스크탑 메뉴 */}
+        <nav className="hidden items-center gap-6 md:flex">
+          {isLoggedIn ? (
+            <>
+              <Link
+                to="/"
+                className={`font-medium hover:text-primary ${
+                  isActive('/') ? 'font-semibold text-primary' : 'text-gray-600'
+                }`}
               >
-                <UserRound className="h-4 w-4" /> 로그인
-              </button>
-            )}
-          </nav>
-
-          {/* 모바일 메뉴 버튼 */}
-          <div className="md:hidden">
-            {isLoggedIn ? (
-              <button onClick={() => setMenuOpen(!menuOpen)} aria-label="메뉴 열기">
-                <Menu className="h-6 w-6 text-gray-700" />
-              </button>
-            ) : (
-              <button
-                onClick={() => setIsLoginModalOpen(true)}
-                className="flex items-center gap-1 rounded-full bg-primary/85 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary/100"
+                마음나무
+              </Link>
+              <Link
+                to="/diary"
+                className={`font-medium hover:text-primary ${
+                  isActive('/diary') ? 'font-semibold text-primary' : 'text-gray-600'
+                }`}
               >
-                <UserRound className="h-4 w-4" /> 로그인
+                일기장
+              </Link>
+              <Link
+                to="/forests"
+                className={`font-medium hover:text-primary ${
+                  isActive('/forests') ? 'font-semibold text-primary' : 'text-gray-600'
+                }`}
+              >
+                이웃숲
+              </Link>
+              <button className="relative" aria-label="알림">
+                <Bell className="h-5 w-5 text-gray-600 hover:text-primary" />
               </button>
-            )}
-          </div>
-        </div>
-
-        {/* 모바일 드롭다운 메뉴 */}
-        {menuOpen && isLoggedIn && (
-          <div className="mt-2 space-y-2 divide-y divide-gray-200 border-t bg-white px-4 py-2 md:hidden">
-            <button className="flex items-center gap-2 py-2 text-sm" aria-label="알림">
-              <Bell className="h-4 w-4 text-gray-600" /> 알림
+              <Link
+                to="/mypage"
+                className="flex items-center gap-1 rounded-full bg-primary/40 px-4 py-1.5 text-xs font-medium text-black/60 transition-colors hover:bg-primary/60"
+              >
+                <UserRound className="h-4 w-4" />
+                {userName}
+              </Link>
+            </>
+          ) : (
+            <button
+              onClick={onLoginClick}
+              className="flex items-center gap-1 rounded-full bg-primary/85 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary/100"
+            >
+              <UserRound className="h-4 w-4" /> 로그인
             </button>
-            <Link
-              to="/"
-              className={`flex items-center gap-2 py-2 text-sm ${
-                isActive('/') ? 'font-semibold text-primary' : 'text-gray-600'
-              }`}
-            >
-              <TreeDeciduous className="h-4 w-4" /> 마음나무
-            </Link>
-            <Link
-              to="/diary"
-              className={`flex items-center gap-2 py-2 text-sm ${
-                isActive('/diary') ? 'font-semibold text-primary' : 'text-gray-600'
-              }`}
-            >
-              <NotebookPen className="h-4 w-4" /> 일기장
-            </Link>
-            <Link
-              to="/forests"
-              className={`flex items-center gap-2 py-2 text-sm ${
-                isActive('/forests') ? 'font-semibold text-primary' : 'text-gray-600'
-              }`}
-            >
-              <Trees className="h-4 w-4" /> 이웃숲
-            </Link>
-            <Link
-              to="/mypage"
-              className={`flex items-center gap-2 py-2 text-sm ${
-                isActive('/mypage') ? 'font-semibold text-primary' : 'text-gray-600'
-              }`}
-            >
-              <UserRound className="h-4 w-4" /> {userName}
-            </Link>
-          </div>
-        )}
-      </header>
+          )}
+        </nav>
 
-      {/* 로그인 모달 */}
-      <LoginModal isOpen={isLoginModalOpen} onClose={() => setIsLoginModalOpen(false)} />
-    </>
+        {/* 모바일 메뉴 버튼 */}
+        <div className="md:hidden">
+          {isLoggedIn ? (
+            <button onClick={() => setMenuOpen(!menuOpen)} aria-label="메뉴 열기">
+              <Menu className="h-6 w-6 text-gray-700" />
+            </button>
+          ) : (
+            <button
+              onClick={onLoginClick}
+              className="flex items-center gap-1 rounded-full bg-primary/85 px-4 py-1.5 text-sm font-medium text-white transition-colors hover:bg-primary/100"
+            >
+              <UserRound className="h-4 w-4" /> 로그인
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* 모바일 드롭다운 메뉴 */}
+      {menuOpen && isLoggedIn && (
+        <div className="mt-2 space-y-2 divide-y divide-gray-200 border-t bg-white px-4 py-2 md:hidden">
+          <button className="flex items-center gap-2 py-2 text-sm" aria-label="알림">
+            <Bell className="h-4 w-4 text-gray-600" /> 알림
+          </button>
+          <Link
+            to="/"
+            className={`flex items-center gap-2 py-2 text-sm ${
+              isActive('/') ? 'font-semibold text-primary' : 'text-gray-600'
+            }`}
+          >
+            <TreeDeciduous className="h-4 w-4" /> 마음나무
+          </Link>
+          <Link
+            to="/diary"
+            className={`flex items-center gap-2 py-2 text-sm ${
+              isActive('/diary') ? 'font-semibold text-primary' : 'text-gray-600'
+            }`}
+          >
+            <NotebookPen className="h-4 w-4" /> 일기장
+          </Link>
+          <Link
+            to="/forests"
+            className={`flex items-center gap-2 py-2 text-sm ${
+              isActive('/forests') ? 'font-semibold text-primary' : 'text-gray-600'
+            }`}
+          >
+            <Trees className="h-4 w-4" /> 이웃숲
+          </Link>
+          <Link
+            to="/mypage"
+            className={`flex items-center gap-2 py-2 text-sm ${
+              isActive('/mypage') ? 'font-semibold text-primary' : 'text-gray-600'
+            }`}
+          >
+            <UserRound className="h-4 w-4" /> {userName}
+          </Link>
+        </div>
+      )}
+    </header>
   );
 };

--- a/src/shared/components/layout/Layout.tsx
+++ b/src/shared/components/layout/Layout.tsx
@@ -1,14 +1,19 @@
+import { useState } from 'react';
 import { Outlet } from 'react-router-dom';
 
+import { AuthModal } from '../auth';
 import { Header } from './Header';
 
 export const Layout = () => {
+  const [modal, setModal] = useState<'login' | 'register' | null>(null);
+
   return (
     <div className="flex min-h-screen flex-col bg-softGray">
-      <Header />
+      <Header onLoginClick={() => setModal('login')} />
       <main className="flex-1 px-4 py-6">
         <Outlet />
       </main>
+      <AuthModal modal={modal} setModal={setModal} />
     </div>
   );
 };


### PR DESCRIPTION
## 요약
### 회원가입 모달 UI 구현
- 로그인 모달 -> 회원가입 모달 전환 자연스럽게 구현
모달의 상태를 기준으로 조건부 랜더링을 하도록 함. (로그인 모달: login, 회원가입 모달: register)
두 모달이 동시에 랜더링되지 않도록하여 버튼 클릭 시 자연스럽게 전환이 되도록 함.

<br><br>

## 작업 내용
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/7b4d9773-80d7-4c08-9abd-a1661977a171" />
<img width="420" alt="image" src="https://github.com/user-attachments/assets/17f5a04f-2457-4be4-bd75-3a39a72dfc90" />


<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #5 

<br><br>
