### PR TITLE
FIX/issue-#20 에러페이지 이미지 오류

### DIFF
--- a/src/pages/error/ui/ErrorPage.tsx
+++ b/src/pages/error/ui/ErrorPage.tsx
@@ -1,13 +1,11 @@
 import { Link } from 'react-router-dom';
 
+import ErrorTodak from '../assets/error-todak.png';
+
 export const ErrorPage = () => {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-white px-6 py-16 text-center">
-      <img
-        src="/src/pages/error/assets/error-todak.png"
-        alt="페이지를 찾을 수 없음"
-        className="w-60"
-      />
+      <img src={ErrorTodak} alt="페이지를 찾을 수 없음" className="w-60" />
       <h1 className="mb-2 text-2xl font-bold text-gray-800">앗! 길을 잃으셨어요</h1>
       <p className="mb-6 text-gray-600">
         요청하신 페이지를 찾을 수 없어요.


### PR DESCRIPTION
## 요약
이미지가 배포 후 보이지 않는 문제 해결 요약
문제 원인
img src="/src/..." 같은 경로를 사용할 경우
 개발 중엔 보이지만, 배포(build) 후엔 404 에러 발생

해결 방법
1. 정적 자산으로 처리
public/ 폴더 하위에 이미지 저장

2. import 방식 사용 (이 방식을 사용함)
Vite가 해당 이미지를 자동으로 처리하고, 빌드 시 정적 경로로 변환

<br><br>

## 작업 내용

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #20 

<br><br>
