### PR TITLE
Fix/issue #39 

### DIFF
--- a/src/shared/apis/auth.ts
+++ b/src/shared/apis/auth.ts
@@ -6,7 +6,9 @@ import { accessToken, refreshToken as refreshTokenUtil } from '../utils/token';
 
 export const signup = async (payload: SignupRequest): Promise<SuccessResponse> => {
   try {
-    const response = await axiosInstance.post<SuccessResponse>('/members/signup', payload);
+    const response = await axiosInstance.post<SuccessResponse>('/members/signup', payload, {
+      skipAuthRefresh: true,
+    });
     return response.data;
   } catch (error) {
     handleAxiosError(error);
@@ -15,7 +17,9 @@ export const signup = async (payload: SignupRequest): Promise<SuccessResponse> =
 };
 
 export const login = async (payload: LoginRequest): Promise<LoginResponse> => {
-  const response = await axiosInstance.post<LoginResponse>('/members/login', payload);
+  const response = await axiosInstance.post<LoginResponse>('/members/login', payload, {
+    skipAuthRefresh: true,
+  });
   return response.data;
 };
 
@@ -50,7 +54,13 @@ export const deleteAccount = async (): Promise<void> => {
 
 export const checkUserId = async (userId: string): Promise<boolean> => {
   try {
-    const response = await axiosInstance.post('/members/check-userId', { userId });
+    const response = await axiosInstance.post(
+      '/members/check-userId',
+      { userId },
+      {
+        skipAuthRefresh: true,
+      },
+    );
     return response.data.data.exists;
   } catch (error) {
     handleAxiosError(error);
@@ -65,7 +75,13 @@ export const refreshAccessToken = async (): Promise<string> => {
   }
 
   try {
-    const response = await axiosInstance.post('/auth/refresh', { refreshToken: refresh });
+    const response = await axiosInstance.post(
+      '/auth/refresh',
+      { refreshToken: refresh },
+      {
+        skipAuthRefresh: true,
+      },
+    );
     const { accessToken: newAccessToken, refreshToken: newRefreshToken } = response.data.data;
 
     accessToken.set(newAccessToken);

--- a/src/shared/components/auth/LoginModal.tsx
+++ b/src/shared/components/auth/LoginModal.tsx
@@ -50,7 +50,7 @@ export const LoginModal = ({ onClose, onSwitch }: LoginModalProps) => {
       if (axios.isAxiosError(error)) {
         const status = error.response?.status;
         if (status === 401) {
-          toast.error('등록되지 않은 계정입니다. 다시 로그인해주세요!');
+          toast.error('등록되지 않은 계정입니다.');
         } else {
           toast.error(error.response?.data?.message || '로그인 중 오류가 발생했습니다.');
         }

--- a/src/shared/lib/axiosInstance.ts
+++ b/src/shared/lib/axiosInstance.ts
@@ -4,6 +4,13 @@ import { refreshAccessToken } from '../apis/auth';
 import { BASE_URL } from '../constants/api';
 import { accessToken, clearTokens } from '../utils/token';
 
+declare module 'axios' {
+  export interface AxiosRequestConfig {
+    skipAuthRefresh?: boolean;
+    _retry?: boolean;
+  }
+}
+
 export const axiosInstance = axios.create({
   baseURL: BASE_URL,
   timeout: 5000,
@@ -11,7 +18,7 @@ export const axiosInstance = axios.create({
 
 axiosInstance.interceptors.request.use(
   (config) => {
-    const token = accessToken.get(); // ✅ 함수에서 객체 메서드로 변경
+    const token = accessToken.get();
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }
@@ -28,7 +35,7 @@ axiosInstance.interceptors.response.use(
     if (
       error.response?.status === 401 &&
       !originalRequest._retry &&
-      originalRequest.url !== '/members/login'
+      !originalRequest.skipAuthRefresh
     ) {
       originalRequest._retry = true;
 

--- a/src/shared/lib/axiosInstance.ts
+++ b/src/shared/lib/axiosInstance.ts
@@ -25,7 +25,11 @@ axiosInstance.interceptors.response.use(
   async (error) => {
     const originalRequest = error.config;
 
-    if (error.response?.status === 401 && !originalRequest._retry) {
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry &&
+      originalRequest.url !== '/members/login'
+    ) {
       originalRequest._retry = true;
 
       try {


### PR DESCRIPTION
## 요약
로그인 실패 시 서버로부터 전달된 에러 메시지(response body)를 정상적으로 처리하지 못하던 문제를 해결했습니다. 
이슈의 원인은 axiosInstance에서 401 상태 코드를 토큰 재발급 로직으로 일괄 처리하면서, 로그인 요청처럼 토큰이 아직 없는 요청의 예외 상황까지 가로채고 있었기 때문입니다.
- 로그인 요청에서 잘못된 아이디나 비밀번호를 입력하면 서버는 401 응답과 함께 "멤버가 존재하지 않습니다."와 같은 에러 메시지를 내려보냄
- 그러나 클라이언트 측에서는 이 response body를 제대로 받아오지 못하고 undefined로 처리됨
- 그 결과 사용자에게 적절한 피드백이 제공되지 않고 모달이 닫히는 등 UX 문제가 발생함

## 작업 내용
1. axios 인터셉터에 skipAuthRefresh 옵션 추가
- 토큰 갱신이 필요 없는 요청(ex. 로그인, 회원가입, 아이디 중복확인 등)에 대해 config.skipAuthRefresh = true 설정
- 해당 요청은 401 응답 시 토큰 재발급 로직을 생략하고 그대로 에러를 처리함
2. axiosInstance.ts 수정
401 처리 로직에서 !config.skipAuthRefresh 조건을 추가해 예외 요청은 그대로 에러를 반환하도록 설정
3. auth API 수정
- 로그인, 회원가입, 아이디 중복확인 요청에 skipAuthRefresh: true 명시
4. loginModal.tsx 개선
- 401 에러가 발생했을 때 사용자에게 "등록되지 않은 계정입니다"와 같은 메시지를 toast로 출력
- 로그인 실패 시 모달이 닫히지 않도록 로직 분리

<br><br>

## 참고 사항
<img width="606" alt="image" src="https://github.com/user-attachments/assets/d0c78bda-a736-4a05-ba80-363107ec0644" />

<br><br>

## 관련 이슈

- Close #39 

<br><br>
