### PR TITLE
Feat/issue #27 일기 댓글 기능 구현

### DIFF
--- a/src/pages/diary/apis/commentsApi.ts
+++ b/src/pages/diary/apis/commentsApi.ts
@@ -1,0 +1,46 @@
+import { axiosInstance } from '@shared/lib';
+import { handleAxiosError } from '@shared/utils';
+
+export const fetchComments = async (
+  diaryId: number,
+  page = 0,
+  size = 5,
+  sort = 'createdAt,desc',
+) => {
+  try {
+    const res = await axiosInstance.get(`/comments/${diaryId}`, {
+      params: { page, size, sort },
+    });
+    return res.data.data;
+  } catch (err) {
+    handleAxiosError(err);
+    throw err;
+  }
+};
+
+export const createComment = async (diaryId: number, content: string) => {
+  try {
+    await axiosInstance.post(`/comments/${diaryId}`, { content });
+  } catch (err) {
+    handleAxiosError(err);
+    throw err;
+  }
+};
+
+export const updateComment = async (commentId: number, content: string) => {
+  try {
+    await axiosInstance.put(`/comments/${commentId}`, { content });
+  } catch (err) {
+    handleAxiosError(err);
+    throw err;
+  }
+};
+
+export const deleteComment = async (commentId: number) => {
+  try {
+    await axiosInstance.delete(`/comments/${commentId}`);
+  } catch (err) {
+    handleAxiosError(err);
+    throw err;
+  }
+};

--- a/src/pages/diary/apis/commentsApi.ts
+++ b/src/pages/diary/apis/commentsApi.ts
@@ -5,7 +5,7 @@ export const fetchComments = async (
   diaryId: number,
   page = 0,
   size = 5,
-  sort = 'createdAt,desc',
+  sort = 'createdAt,asc',
 ) => {
   try {
     const res = await axiosInstance.get(`/comments/${diaryId}`, {
@@ -42,5 +42,14 @@ export const deleteComment = async (commentId: number) => {
   } catch (err) {
     handleAxiosError(err);
     throw err;
+  }
+};
+
+export const revealCommentAuthor = async (commentId: number): Promise<void> => {
+  try {
+    await axiosInstance.post(`/comments/reveal/${commentId}`);
+  } catch (error) {
+    handleAxiosError(error);
+    throw error;
   }
 };

--- a/src/pages/diary/apis/index.ts
+++ b/src/pages/diary/apis/index.ts
@@ -1,1 +1,2 @@
 export * from './diaryApi';
+export * from './commentsApi';

--- a/src/pages/diary/components/CommentSection.tsx
+++ b/src/pages/diary/components/CommentSection.tsx
@@ -1,0 +1,190 @@
+import { useState } from 'react';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { createComment, deleteComment, fetchComments, updateComment } from '../apis/commentsApi';
+
+type CommentSectionProps = {
+  diaryId: number;
+};
+
+type Comment = {
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+  nickname: string;
+  userId: string;
+  content: string;
+  isWriter: boolean;
+  isAnonymous: boolean;
+};
+
+type CommentResponse = {
+  content: Comment[];
+  number: number;
+  totalPages: number;
+  last: boolean;
+};
+
+export const CommentSection = ({ diaryId }: CommentSectionProps) => {
+  const queryClient = useQueryClient();
+  const [page, setPage] = useState(0);
+  const [newComment, setNewComment] = useState('');
+  const [editingMap, setEditingMap] = useState<Record<number, string>>({});
+
+  const { data, isLoading } = useQuery<
+    CommentResponse,
+    Error,
+    CommentResponse,
+    [string, number, number]
+  >({
+    queryKey: ['comments', diaryId, page] as const,
+    queryFn: () => fetchComments(diaryId, page, 5),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: () => createComment(diaryId, newComment),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments', diaryId] });
+      setNewComment('');
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, content }: { id: number; content: string }) => updateComment(id, content),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments', diaryId] });
+      setEditingMap({});
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteComment(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments', diaryId] });
+    },
+  });
+
+  if (isLoading) return <p className="text-sm text-gray-500">댓글을 불러오는 중이에요...</p>;
+
+  const sortedComments = [...(data?.content ?? [])].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+  );
+
+  return (
+    <div className="mt-6 rounded-xl bg-white p-4 shadow-sm">
+      <h3 className="mb-4 text-sm font-semibold text-primary">🌱 댓글</h3>
+      <div className="space-y-4">
+        {sortedComments.map((comment) => {
+          const isEditing = Object.prototype.hasOwnProperty.call(editingMap, comment.id);
+          return (
+            <div
+              key={comment.id}
+              className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 shadow-sm"
+            >
+              <p className="mb-1 text-xs text-gray-500">
+                <span className="font-medium text-gray-700">{comment.nickname}</span>{' '}
+                <span className="text-[11px] text-gray-400">({comment.userId})</span> ·{' '}
+                {new Date(comment.createdAt).toLocaleString()}
+              </p>
+              {isEditing ? (
+                <>
+                  <textarea
+                    value={editingMap[comment.id]}
+                    onChange={(e) =>
+                      setEditingMap((prev) => ({ ...prev, [comment.id]: e.target.value }))
+                    }
+                    className="w-full rounded-md border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                  />
+                  <div className="mt-2 flex gap-3 text-xs">
+                    <button
+                      onClick={() =>
+                        updateMutation.mutate({ id: comment.id, content: editingMap[comment.id] })
+                      }
+                      className="rounded bg-primary px-3 py-1 text-white hover:bg-primary/90"
+                    >
+                      저장
+                    </button>
+                    <button
+                      onClick={() =>
+                        setEditingMap((prev) => {
+                          const newMap = { ...prev };
+                          delete newMap[comment.id];
+                          return newMap;
+                        })
+                      }
+                      className="text-gray-500 hover:underline"
+                    >
+                      취소
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <p className="whitespace-pre-wrap text-sm text-gray-800">{comment.content}</p>
+                  {comment.isWriter && (
+                    <div className="mt-2 flex gap-3 text-xs">
+                      <button
+                        onClick={() =>
+                          setEditingMap((prev) => ({ ...prev, [comment.id]: comment.content }))
+                        }
+                        className="text-primary hover:underline"
+                      >
+                        수정
+                      </button>
+                      <button
+                        onClick={() => deleteMutation.mutate(comment.id)}
+                        className="text-red-500 hover:underline"
+                      >
+                        삭제
+                      </button>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="mt-6 flex items-center justify-between text-xs text-gray-500">
+        <button
+          onClick={() => setPage((p) => Math.max(0, p - 1))}
+          disabled={page === 0}
+          className="hover:underline disabled:text-gray-300"
+        >
+          이전
+        </button>
+        <span>{data ? `${data.number + 1} / ${data.totalPages}` : '...'}</span>
+        <button
+          onClick={() => setPage((p) => (data && !data.last ? p + 1 : p))}
+          disabled={!data || data.last}
+          className="hover:underline disabled:text-gray-300"
+        >
+          다음
+        </button>
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (newComment.trim()) createMutation.mutate();
+        }}
+        className="mt-6"
+      >
+        <textarea
+          value={newComment}
+          onChange={(e) => setNewComment(e.target.value)}
+          placeholder="마음을 담은 댓글을 남겨보세요..."
+          className="min-h-[80px] w-full rounded-lg border px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+        />
+        <button
+          type="submit"
+          className="mt-2 w-full rounded-lg bg-primary py-2 text-white transition hover:bg-primary/90"
+        >
+          댓글 작성
+        </button>
+      </form>
+    </div>
+  );
+};

--- a/src/pages/diary/components/DiaryEditor.tsx
+++ b/src/pages/diary/components/DiaryEditor.tsx
@@ -136,7 +136,7 @@ export const DiaryEditor = ({
 
     const formData = new FormData();
     formData.append('file', file);
-    formData.append('storageUUID', storageUUID);
+    formData.append('storageUUID', String(storageUUID));
 
     try {
       const response = await uploadImage(formData);

--- a/src/pages/diary/components/DiaryViewer.tsx
+++ b/src/pages/diary/components/DiaryViewer.tsx
@@ -68,7 +68,7 @@ export const DiaryViewer = ({ diaryId, date, onClose, onDeleted }: DiaryViewerPr
 
   if (!diary || !isReadyToRender) {
     return (
-      <div className="mx-auto w-full max-w-xl rounded-xl bg-white px-6 py-8 text-center shadow-md">
+      <div className="mx-auto w-full rounded-xl bg-white px-6 py-8 text-center shadow-md sm:max-w-sm lg:max-w-xl">
         <div className="mb-4 text-[15px] font-normal leading-relaxed text-gray-800">
           잠시만요, 추억을 펼치는 중이에요... 📖
         </div>
@@ -92,8 +92,8 @@ export const DiaryViewer = ({ diaryId, date, onClose, onDeleted }: DiaryViewerPr
         storageUUID={diary.storageUUID}
         onClose={onClose}
         onSwitchToViewer={(updatedDiary) => {
-          setDiary(updatedDiary); // 수정된 데이터 반영
-          setIsEditing(false); // 다시 뷰어 모드로 전환
+          setDiary(updatedDiary);
+          setIsEditing(false);
         }}
       />
     );

--- a/src/pages/diary/components/DiaryViewer.tsx
+++ b/src/pages/diary/components/DiaryViewer.tsx
@@ -7,6 +7,7 @@ import remarkBreaks from 'remark-breaks';
 
 import { deleteDiary, fetchDiaryDetail } from '../apis';
 import type { DiaryDetail } from '../types';
+import { CommentSection } from './CommentSection';
 import { DiaryEditor } from './DiaryEditor';
 
 const emotionLabels: Record<string, string> = {
@@ -166,6 +167,7 @@ export const DiaryViewer = ({ diaryId, date, onClose, onDeleted }: DiaryViewerPr
           </button>
         </div>
       )}
+      <CommentSection diaryId={diary.diaryId} />
     </div>
   );
 };

--- a/src/shared/components/layout/AppInit.tsx
+++ b/src/shared/components/layout/AppInit.tsx
@@ -2,8 +2,7 @@ import { useEffect } from 'react';
 
 import { refreshAccessToken } from '@shared/apis';
 import { useAuthStore } from '@shared/stores/authStore';
-import { refreshToken } from '@shared/utils/token';
-import { clearTokens } from '@shared/utils/token';
+import { clearTokens, refreshToken } from '@shared/utils/token';
 
 export const AppInit = () => {
   const { login, logout } = useAuthStore();
@@ -14,9 +13,8 @@ export const AppInit = () => {
       if (!refresh) return;
 
       try {
-        const newAccessToken = await refreshAccessToken();
-
-        console.log('AccessToken 재발급 성공:', newAccessToken);
+        await refreshAccessToken();
+        // console.log('AccessToken 재발급 성공:', newAccessToken); // 필요 없다면 제거
       } catch {
         clearTokens();
         logout();


### PR DESCRIPTION
## 요약
일기 상세 페이지에서 댓글 작성, 수정, 삭제, 익명 해제 기능을 구현함.
댓글은 페이지네이션 방식으로 오래된 순서대로 표시되며, 본인이 작성한 댓글만 수정 및 삭제가 가능함.

<br><br>

## 작업 내용
CommentSection.tsx 컴포넌트 생성 및 스타일링

댓글 CRUD API 호출을 위한 commentsApi.ts 구현

useMutation, useQuery를 활용한 댓글 데이터 비동기 처리

익명 댓글 작성자 정보 해제 기능 추가 (POST /comments/reveal/{commentId})

댓글 수정 시 다른 댓글에 영향이 없도록 editingMap으로 개별 상태 관리

작성자 닉네임 및 ID 표시 및 익명 여부에 따른 UI 처리

페이지네이션 구현 (오래된 댓글이 첫 페이지에, 최신 댓글은 마지막 페이지에 위치)

댓글 작성 입력창에 최소 높이 설정 및 스타일 개선

댓글 로딩 시 초록색 스피너 표시

익명 해제 성공/실패 시 토스트 알림 처리

<br><br>

## 참고 사항
익명 해제 시 2포인트가 차감되며, 포인트 부족 시 실패 알림이 뜹니다.

<br><br>

## 관련 이슈

- Close #27

<br><br>
